### PR TITLE
Allow instance IP ordering and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This exporter can be deployed using the [Prometheus BOSH Release][prometheus-bos
 
 ### Flags
 
+
+
 | Flag / Environment Variable | Required | Default | Description |
 | --------------------------- | -------- | ------- | ----------- |
 | `bosh.url`<br />`BOSH_EXPORTER_BOSH_URL` | Yes | | BOSH URL |
@@ -68,6 +70,7 @@ This exporter can be deployed using the [Prometheus BOSH Release][prometheus-bos
 | `filter.deployments`<br />`BOSH_EXPORTER_FILTER_DEPLOYMENTS` | No | | Comma separated deployments to filter |
 | `filter.azs`<br />`BOSH_EXPORTER_FILTER_AZS` | No | | Comma separated AZs to filter |
 | `filter.collectors`<br />`BOSH_EXPORTER_FILTER_COLLECTORS` | No | | Comma separated collectors to filter. If not set, all collectors will be enabled  (`Deployments`, `Jobs`, `ServiceDiscovery`) |
+| `filter.cidrs`<br />`BOSH_EXPORTER_FILTER_CIDRS` | No | `0.0.0.0/0` | Comma separated CIDR to filter instance IPs |
 | `metrics.namespace`<br />`BOSH_EXPORTER_METRICS_NAMESPACE` | No | `bosh` | Metrics Namespace |
 | `metrics.environment`<br />`BOSH_EXPORTER_METRICS_ENVIRONMENT` | Yes | | Environment label to be attached to metrics |
 | `sd.filename`<br />`BOSH_EXPORTER_SD_FILENAME` | No | `bosh_target_groups.json` | Full path to the Service Discovery output file |
@@ -162,6 +165,16 @@ If the `ServiceDiscovery` collector is enabled, the exporter will write a `json`
 ```
 
 The list of targets can be filtered using the `sd.processes_regexp` flag.
+
+
+## Filtering IPs
+
+Available instance IPs can be filtered using the `filter.cidrs` flag. 
+
+The first IP that matches a CIDR is used as target. 
+CIDRs are tested in the order specified by the comma-seperated list. 
+The instance is dropped if no IP is included in any of the CIDRs.
+
 
 ## Contributing
 

--- a/bosh_exporter.go
+++ b/bosh_exporter.go
@@ -62,6 +62,10 @@ var (
 		"filter.collectors", "Comma separated collectors to filter (Deployments,Jobs,ServiceDiscovery) ($BOSH_EXPORTER_FILTER_COLLECTORS)",
 	).Envar("BOSH_EXPORTER_FILTER_COLLECTORS").Default("").String()
 
+	filterCIDRs = kingpin.Flag(
+		"filter.cidrs", "Comma separated CIDR to filter available instance IPs ($BOSH_EXPORTER_FILTER_CIDRS)",
+	).Envar("BOSH_EXPORTER_FILTER_CIDRS").Default("0,0.0.0.0/0").String()
+
 	metricsNamespace = kingpin.Flag(
 		"metrics.namespace", "Metrics Namespace ($BOSH_EXPORTER_METRICS_NAMESPACE)",
 	).Envar("BOSH_EXPORTER_METRICS_NAMESPACE").Default("bosh").String()
@@ -295,6 +299,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	var cidrFilters []string
+	if *filterCIDRs != "" {
+		cidrFilters = strings.Split(*filterCIDRs, ",")
+	}
+	cidrsFilter, err := filters.NewCidrFilter(cidrFilters)
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
 	var processesFilters []string
 	if *sdProcessesRegexp != "" {
 		processesFilters = []string{*sdProcessesRegexp}
@@ -315,6 +329,7 @@ func main() {
 		collectorsFilter,
 		azsFilter,
 		processesFilter,
+		cidrsFilter,
 	)
 	prometheus.MustRegister(boshCollector)
 

--- a/collectors/bosh_collector.go
+++ b/collectors/bosh_collector.go
@@ -31,6 +31,7 @@ func NewBoshCollector(
 	collectorsFilter *filters.CollectorsFilter,
 	azsFilter *filters.AZsFilter,
 	processesFilter *filters.RegexpFilter,
+	cidrsFilter *filters.CidrFilter,
 ) *BoshCollector {
 	enabledCollectors := []Collector{}
 
@@ -40,7 +41,7 @@ func NewBoshCollector(
 	}
 
 	if collectorsFilter.Enabled(filters.JobsCollector) {
-		jobsCollector := NewJobsCollector(namespace, environment, boshName, boshUUID, azsFilter)
+		jobsCollector := NewJobsCollector(namespace, environment, boshName, boshUUID, azsFilter, cidrsFilter)
 		enabledCollectors = append(enabledCollectors, jobsCollector)
 	}
 
@@ -53,6 +54,7 @@ func NewBoshCollector(
 			serviceDiscoveryFilename,
 			azsFilter,
 			processesFilter,
+			cidrsFilter,
 		)
 		enabledCollectors = append(enabledCollectors, serviceDiscoveryCollector)
 	}

--- a/collectors/bosh_collector_test.go
+++ b/collectors/bosh_collector_test.go
@@ -41,6 +41,7 @@ var _ = Describe("BoshCollector", func() {
 		collectorsFilter   *filters.CollectorsFilter
 		azsFilter          *filters.AZsFilter
 		processesFilter    *filters.RegexpFilter
+		cidrsFilter        *filters.CidrFilter
 		boshCollector      *BoshCollector
 
 		totalBoshScrapesMetric              prometheus.Counter
@@ -66,6 +67,8 @@ var _ = Describe("BoshCollector", func() {
 		collectorsFilter, err = filters.NewCollectorsFilter([]string{})
 		Expect(err).ToNot(HaveOccurred())
 		azsFilter = filters.NewAZsFilter([]string{})
+		cidrsFilter, err = filters.NewCidrFilter([]string{"0.0.0.0/0"})
+		Expect(err).ToNot(HaveOccurred())
 		processesFilter, err = filters.NewRegexpFilter([]string{})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -160,6 +163,7 @@ var _ = Describe("BoshCollector", func() {
 			collectorsFilter,
 			azsFilter,
 			processesFilter,
+			cidrsFilter,
 		)
 	})
 

--- a/collectors/jobs_collector.go
+++ b/collectors/jobs_collector.go
@@ -14,6 +14,7 @@ import (
 
 type JobsCollector struct {
 	azsFilter                           *filters.AZsFilter
+	cidrsFilter                         *filters.CidrFilter
 	jobHealthyMetric                    *prometheus.GaugeVec
 	jobLoadAvg01Metric                  *prometheus.GaugeVec
 	jobLoadAvg05Metric                  *prometheus.GaugeVec
@@ -46,6 +47,7 @@ func NewJobsCollector(
 	boshName string,
 	boshUUID string,
 	azsFilter *filters.AZsFilter,
+	cidrsFilter *filters.CidrFilter,
 ) *JobsCollector {
 	jobHealthyMetric := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -407,6 +409,7 @@ func NewJobsCollector(
 
 	collector := &JobsCollector{
 		azsFilter:                           azsFilter,
+		cidrsFilter:                         cidrsFilter,
 		jobHealthyMetric:                    jobHealthyMetric,
 		jobLoadAvg01Metric:                  jobLoadAvg01Metric,
 		jobLoadAvg05Metric:                  jobLoadAvg05Metric,
@@ -538,10 +541,7 @@ func (c *JobsCollector) reportJobMetrics(deployment deployments.DeploymentInfo, 
 		jobID := instance.ID
 		jobIndex := instance.Index
 		jobAZ := instance.AZ
-		jobIP := ""
-		if len(instance.IPs) > 0 {
-			jobIP = instance.IPs[0]
-		}
+		jobIP, _ := c.cidrsFilter.Select(instance.IPs)
 
 		err = c.jobHealthyMetrics(ch, instance.Healthy, deploymentName, jobName, jobID, jobIndex, jobAZ, jobIP)
 		err = c.jobLoadAvgMetrics(ch, instance.Vitals.Load, deploymentName, jobName, jobID, jobIndex, jobAZ, jobIP)

--- a/collectors/jobs_collector_test.go
+++ b/collectors/jobs_collector_test.go
@@ -22,11 +22,13 @@ func init() {
 
 var _ = Describe("JobsCollector", func() {
 	var (
+		err           error
 		namespace     string
 		environment   string
 		boshName      string
 		boshUUID      string
 		azsFilter     *filters.AZsFilter
+		cidrsFilter   *filters.CidrFilter
 		jobsCollector *JobsCollector
 
 		jobHealthyMetric                    *prometheus.GaugeVec
@@ -91,6 +93,8 @@ var _ = Describe("JobsCollector", func() {
 		boshName = "test_bosh_name"
 		boshUUID = "test_bosh_uuid"
 		azsFilter = filters.NewAZsFilter([]string{})
+		cidrsFilter, err = filters.NewCidrFilter([]string{"0.0.0.0/0"})
+		Expect(err).ToNot(HaveOccurred())
 
 		jobHealthyMetric = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -655,7 +659,7 @@ var _ = Describe("JobsCollector", func() {
 	})
 
 	JustBeforeEach(func() {
-		jobsCollector = NewJobsCollector(namespace, environment, boshName, boshUUID, azsFilter)
+		jobsCollector = NewJobsCollector(namespace, environment, boshName, boshUUID, azsFilter, cidrsFilter)
 	})
 
 	Describe("Describe", func() {

--- a/collectors/service_discovery_collector_test.go
+++ b/collectors/service_discovery_collector_test.go
@@ -31,6 +31,7 @@ var _ = Describe("ServiceDiscoveryCollector", func() {
 		serviceDiscoveryFilename  string
 		azsFilter                 *filters.AZsFilter
 		processesFilter           *filters.RegexpFilter
+		cidrsFilter               *filters.CidrFilter
 		serviceDiscoveryCollector *ServiceDiscoveryCollector
 
 		lastServiceDiscoveryScrapeTimestampMetric       prometheus.Gauge
@@ -46,6 +47,7 @@ var _ = Describe("ServiceDiscoveryCollector", func() {
 		Expect(err).ToNot(HaveOccurred())
 		serviceDiscoveryFilename = tmpfile.Name()
 		azsFilter = filters.NewAZsFilter([]string{})
+		cidrsFilter, err = filters.NewCidrFilter([]string{"0.0.0.0/0"})
 		processesFilter, err = filters.NewRegexpFilter([]string{})
 
 		lastServiceDiscoveryScrapeTimestampMetric = prometheus.NewGauge(
@@ -91,6 +93,7 @@ var _ = Describe("ServiceDiscoveryCollector", func() {
 			serviceDiscoveryFilename,
 			azsFilter,
 			processesFilter,
+			cidrsFilter,
 		)
 	})
 

--- a/filters/cidr_filter.go
+++ b/filters/cidr_filter.go
@@ -1,0 +1,38 @@
+package filters
+
+import (
+	"net"
+)
+
+type CidrFilter struct {
+	cidrFilters []*net.IPNet
+}
+
+func NewCidrFilter(cidrs []string) (*CidrFilter, error) {
+	nets := []*net.IPNet{}
+	for _, c := range cidrs {
+		_, net, err := net.ParseCIDR(c)
+		if err != nil {
+			return nil, err
+		}
+		nets = append(nets, net)
+	}
+	return &CidrFilter{
+		cidrFilters: nets,
+	}, nil
+}
+
+func (f *CidrFilter) Select(ips []string) (string, bool) {
+	for _, c := range f.cidrFilters {
+		for _, val := range ips {
+			ip := net.ParseIP(val)
+			if ip == nil {
+				continue
+			}
+			if c.Contains(ip) {
+				return val, true
+			}
+		}
+	}
+	return "", false
+}

--- a/filters/cidr_filter_test.go
+++ b/filters/cidr_filter_test.go
@@ -23,7 +23,6 @@ var _ = Describe("Cidr Filter", func() {
 			BeforeEach(func() {
 				cidrs = []string{"0.0.0.0/0", "10.250.0.0/16"}
 			})
-
 			It("does not return an error", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -33,7 +32,6 @@ var _ = Describe("Cidr Filter", func() {
 			BeforeEach(func() {
 				cidrs = []string{"not.a.cidr"}
 			})
-
 			It("returns an error", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("invalid CIDR address: not.a.cidr"))
@@ -48,21 +46,21 @@ var _ = Describe("Cidr Filter", func() {
 				cidrs = []string{"0.0.0.0/0"}
 			})
 			Context("when selecting single ip", func() {
-				It("returns first ip", func() {
+				It("returns first ip/true", func() {
 					ip, found := cidrFilter.Select([]string{"192.168.0.1"})
 					Expect(found).To(BeTrue())
 					Expect(ip).To(Equal("192.168.0.1"))
 				})
 			})
 			Context("when selecting multiple ips", func() {
-				It("returns first ip", func() {
+				It("returns first ip/true", func() {
 					ip, found := cidrFilter.Select([]string{"192.168.0.1", "10.254.12.57"})
 					Expect(found).To(BeTrue())
 					Expect(ip).To(Equal("192.168.0.1"))
 				})
 			})
 			Context("when selecting empty list", func() {
-				It("returns false", func() {
+				It("returns empty/false", func() {
 					ip, found := cidrFilter.Select([]string{})
 					Expect(found).To(BeFalse())
 					Expect(ip).To(Equal(""))
@@ -75,14 +73,14 @@ var _ = Describe("Cidr Filter", func() {
 				cidrs = []string{"10.254.0.0/16", "0.0.0.0/0"}
 			})
 			Context("when selecting single ip", func() {
-				It("returns first ip", func() {
+				It("returns first ip/true", func() {
 					ip, found := cidrFilter.Select([]string{"192.168.0.1"})
 					Expect(found).To(BeTrue())
 					Expect(ip).To(Equal("192.168.0.1"))
 				})
 			})
 			Context("when selecting multiple ips", func() {
-				It("returns first ip", func() {
+				It("returns second ip/true", func() {
 					ip, found := cidrFilter.Select([]string{"192.168.0.1", "10.254.12.57"})
 					Expect(found).To(BeTrue())
 					Expect(ip).To(Equal("10.254.12.57"))
@@ -95,14 +93,14 @@ var _ = Describe("Cidr Filter", func() {
 				cidrs = []string{"10.254.0.0/16"}
 			})
 			Context("with matching ip", func() {
-				It("returns first ip", func() {
+				It("returns first ip/true", func() {
 					ip, found := cidrFilter.Select([]string{"10.254.1.1"})
 					Expect(found).To(BeTrue())
 					Expect(ip).To(Equal("10.254.1.1"))
 				})
 			})
 			Context("with unmatching ip", func() {
-				It("returns first ip", func() {
+				It("returns empty/false", func() {
 					ip, found := cidrFilter.Select([]string{"192.168.0.1"})
 					Expect(found).To(BeFalse())
 					Expect(ip).To(Equal(""))

--- a/filters/cidr_filter_test.go
+++ b/filters/cidr_filter_test.go
@@ -1,0 +1,113 @@
+package filters_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/bosh-prometheus/bosh_exporter/filters"
+)
+
+var _ = Describe("Cidr Filter", func() {
+	var (
+		err        error
+		cidrs      []string
+		cidrFilter *CidrFilter
+	)
+
+	JustBeforeEach(func() {
+		cidrFilter, err = NewCidrFilter(cidrs)
+	})
+
+	Describe("New", func() {
+		Context("when valid cidr", func() {
+			BeforeEach(func() {
+				cidrs = []string{"0.0.0.0/0", "10.250.0.0/16"}
+			})
+
+			It("does not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when invalid cidr", func() {
+			BeforeEach(func() {
+				cidrs = []string{"not.a.cidr"}
+			})
+
+			It("returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("invalid CIDR address: not.a.cidr"))
+			})
+		})
+	})
+
+	Describe("Select", func() {
+
+		Describe("with default cidr", func() {
+			BeforeEach(func() {
+				cidrs = []string{"0.0.0.0/0"}
+			})
+			Context("when selecting single ip", func() {
+				It("returns first ip", func() {
+					ip, found := cidrFilter.Select([]string{"192.168.0.1"})
+					Expect(found).To(BeTrue())
+					Expect(ip).To(Equal("192.168.0.1"))
+				})
+			})
+			Context("when selecting multiple ips", func() {
+				It("returns first ip", func() {
+					ip, found := cidrFilter.Select([]string{"192.168.0.1", "10.254.12.57"})
+					Expect(found).To(BeTrue())
+					Expect(ip).To(Equal("192.168.0.1"))
+				})
+			})
+			Context("when selecting empty list", func() {
+				It("returns false", func() {
+					ip, found := cidrFilter.Select([]string{})
+					Expect(found).To(BeFalse())
+					Expect(ip).To(Equal(""))
+				})
+			})
+		})
+
+		Describe("with multiple cidr", func() {
+			BeforeEach(func() {
+				cidrs = []string{"10.254.0.0/16", "0.0.0.0/0"}
+			})
+			Context("when selecting single ip", func() {
+				It("returns first ip", func() {
+					ip, found := cidrFilter.Select([]string{"192.168.0.1"})
+					Expect(found).To(BeTrue())
+					Expect(ip).To(Equal("192.168.0.1"))
+				})
+			})
+			Context("when selecting multiple ips", func() {
+				It("returns first ip", func() {
+					ip, found := cidrFilter.Select([]string{"192.168.0.1", "10.254.12.57"})
+					Expect(found).To(BeTrue())
+					Expect(ip).To(Equal("10.254.12.57"))
+				})
+			})
+		})
+
+		Describe("with specific cidr", func() {
+			BeforeEach(func() {
+				cidrs = []string{"10.254.0.0/16"}
+			})
+			Context("with matching ip", func() {
+				It("returns first ip", func() {
+					ip, found := cidrFilter.Select([]string{"10.254.1.1"})
+					Expect(found).To(BeTrue())
+					Expect(ip).To(Equal("10.254.1.1"))
+				})
+			})
+			Context("with unmatching ip", func() {
+				It("returns first ip", func() {
+					ip, found := cidrFilter.Select([]string{"192.168.0.1"})
+					Expect(found).To(BeFalse())
+					Expect(ip).To(Equal(""))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
This PR allows users to choose which IP of the bosh instance to use as target and label as requested in #17 

### How it works

* It adds a new parameter `filter.cidrs` that gives a coma-seperated list of `CIDR`. 
* Each instance IP is matched against each `CIDR` in the order given by the list
* The first match gives the IP to use as target and label
* Default value for `filter.cidrs` is `0.0.0.0/0` which matches any IP. Consequently, the default behavior is unchanged: the first available IP is used.
* When couldn't match any IPs to any given `CIDR`, the instance is dropped (which provides a way to filter-out instances by their IP)

### Example:

* Given two instances with their IPs
  * `A`: `172.30.0.3` and `10.234.244.37`
  * `B`: `192.168.0.55`

* With ```--filter.cidrs="0.0.0.0/0"``` (default flag value)
  * step A1. `172.30.0.3` is checked against `0.0.0.0/0`, **match**
    * `172.30.0.3` is used for `A`
  * step B1. `192.168.0.55` is checked against `0.0.0.0/0`, **match**
    * `192.168.0.55` is used for `B`


* With ```--filter.cidrs="10.234.0.0/16,0.0.0.0/0"```
  * step A1. `172.30.0.3` is checked against `10.234.0.0/16`, **no match**
  * step A2. `10.234.244.37` is checked against `10.234.0.0/16`, **match**
    * `10.234.244.37` is used for `A`
  * step B1. `192.168.0.55` is checked against `10.234.0.0/16`, **no match**
  * step B2. `192.168.0.55` is checked against `0.0.0.0/0`, **match**
    * `192.168.0.55` is used for `B`