### PR TITLE
Use go install to set up promu

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -20,7 +20,6 @@ tarball:
     - NOTICE
 crossbuild:
   platforms:
-    - darwin/386
     - darwin/amd64
     - linux/386
     - linux/amd64

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test: deps
 promu:
 	@GOOS=$(shell uname -s | tr A-Z a-z) \
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
-		$(GO) get -u github.com/prometheus/promu
+		$(GO) install github.com/prometheus/promu@v0.13.0
 
 build: promu
 	@echo ">> building binaries"


### PR DESCRIPTION
Fix promu builds since #32. Using `go get` inside the repo dir has caused upgrades in vendored dependencies from Go 1.16.

```
$ promu crossbuild -c .promu.yml
1.17-base: Pulling from prometheus/golang-builder
Digest: sha256:5f2ff5d8f1ec5f5d0ee99b2e175556a66d09cfde0824154dac8c7cdca490a134
Status: Image is up to date for quay.io/prometheus/golang-builder:1.17-base
quay.io/prometheus/golang-builder:1.17-base
> running the base builder docker image
da2dee61804b71a2ab798388259693889f72fc8e7d781f06379f2c6db57ec1e0
# darwin-amd64
go: downloading github.com/prometheus/promu v0.13.0
go: downloading github.com/google/go-github/v25 v25.1.3
go: downloading go.uber.org/atomic v1.9.0
go: downloading github.com/prometheus/common v0.32.1
go: downloading github.com/pkg/errors v0.9.1
go: downloading golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
go: downloading gopkg.in/alecthomas/kingpin.v2 v2.2.6
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading github.com/Masterminds/semver v1.5.0
go: downloading github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
go: downloading github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
go: downloading golang.org/x/net v0.0.0-20210525063256-abc453219eb5
go: downloading github.com/prometheus/client_golang v1.11.0
go: downloading github.com/google/go-querystring v1.0.0
go: downloading github.com/prometheus/procfs v0.6.0
go: downloading github.com/golang/protobuf v1.4.3
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading google.golang.org/protobuf v1.26.0-rc.1
go: downloading golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40
>> building binaries
 >   bosh_exporter
# linux-386
>> building binaries
 >   bosh_exporter
# linux-amd64
>> building binaries
 >   bosh_exporter
# linux-arm64
>> building binaries
 >   bosh_exporter
# linux-armv5
>> building binaries
 >   bosh_exporter
# linux-armv6
>> building binaries
 >   bosh_exporter
# linux-armv7
>> building binaries
 >   bosh_exporter
# linux-ppc64
>> building binaries
 >   bosh_exporter
# linux-ppc64le
>> building binaries
 >   bosh_exporter
# windows-386
>> building binaries
 >   bosh_exporter.exe
# windows-amd64
>> building binaries
 >   bosh_exporter.exe
promu-crossbuild-base1660207673-0
```